### PR TITLE
Update duracloud dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,13 +68,13 @@
     <dependency>
       <groupId>org.duracloud</groupId>
       <artifactId>common</artifactId>
-      <version>4.0.0</version>
+      <version>4.4.6</version>
     </dependency>
 
     <dependency>
       <groupId>org.duracloud</groupId>
       <artifactId>storeclient</artifactId>
-      <version>4.0.0</version>
+      <version>4.4.6</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Doesn't work against *.duracloud.org with 4.0.0 - updated to 4.4.6. Simple
example then works.